### PR TITLE
Moved tensorflow

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,6 @@ dependencies:
     - h5py
     - seaborn
     - pandas
+    - tensorflow
     - pip:
-        - tensorflow
         - git+https://github.com/fchollet/keras.git


### PR DESCRIPTION
To conda-forge download dependency, was getting ```CondaValueError: Value error: pip returned an error.``` for Ubuntu 16.04.